### PR TITLE
Add license key to pyproject.toml

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "{{ cookiecutter.project_name }}"
 readme = "README.md"
+license = {file = "LICENSE"}
 authors = [
     {name = "{{ cookiecutter.author_name }}", email = "{{ cookiecutter.author_email }}"}
 ]


### PR DESCRIPTION
I think this is related to https://github.com/astrojuanlu/cookiecutter-pylib/issues/5. There are probably more fields from 621 to add, but this one is probably the most important to comply with the license and in case the library made it to conda-forge eventually (what made me update this in fact :sweat_smile:)