### PR TITLE
Use single line description in project docstring

### DIFF
--- a/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_name}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -1,8 +1,4 @@
-"""
-{{ cookiecutter.project_name }}
-
-{{ cookiecutter.short_description }}
-"""
+"""{{ cookiecutter.short_description }}."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
This fixes the issue of flit not retrieving the correct short description for the project. Closes #10 