### PR TITLE
fix ci and run for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,4 @@
 name: Run tests
-on: push
 on:
   pull_request:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Run tests
 on: push
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   test:

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
 [testenv:check]
 skip_install = true
 deps =
-    black==21.11b1
+    black
     isort
     flake8
     mypy
@@ -46,7 +46,7 @@ commands =
 [testenv:reformat]
 skip_install = true
 deps =
-    black==21.11b1
+    black
     isort
 commands =
     isort --section-default THIRDPARTY tests

--- a/{{cookiecutter.project_name}}/tox.ini
+++ b/{{cookiecutter.project_name}}/tox.ini
@@ -39,7 +39,7 @@ commands =
 [testenv:check]
 skip_install = true
 deps =
-    black==21.11b1
+    black
     isort
     flake8
     pydocstyle
@@ -52,7 +52,7 @@ commands =
 [testenv:reformat]
 skip_install = true
 deps =
-    black==21.11b1
+    black
     isort
 commands =
     isort --project {{ cookiecutter.package_name }} --section-default THIRDPARTY src tests


### PR DESCRIPTION
I removed the pin on black release which seems to fix the issues locally.

I was also thinking it might be a good idea to update the tox envs to follow https://scientific-python.org/specs/spec-0000/ (that is, for now test on 3.8, 3.9 and 3.10).